### PR TITLE
Matching algorithm based on backwards search

### DIFF
--- a/snippets.kak
+++ b/snippets.kak
@@ -21,7 +21,7 @@ hook global WinSetOption 'snippets=.+$' %{
 def snippets-expand-trigger-internal -hidden -params ..1 %{
     # early-out if we're not selecting a valid trigger
     evaluate-commands -save-regs "a" %{
-        exec -draft %{<a-?>%opt{snippets_expand_filter}<a-!><ret><a-;>H"aZ}
+        exec -draft %{hGhs%opt{snippets_expand_filter}<a-!>\z<ret><a-;>"aZ}
         eval %sh{
             eval set -- "$kak_opt_snippets"
             if [ $(($#%3)) -ne 0 ]; then exit; fi

--- a/snippets.kak
+++ b/snippets.kak
@@ -33,7 +33,7 @@ def snippets-expand-trigger-internal -hidden -params ..1 %{
                 else
                     printf '} catch %%{'
                 fi
-                printf "exec -draft %%{\"az<a-k>%s<ret>d}\n" "$2"
+                printf "exec -draft %%{\"az<a-k>\A%s\z<ret>d}\n" "$2"
                 printf "snippets %%{%s}\n" "$1"
                 shift 3
             done


### PR DESCRIPTION
Do a backwards search to select a possible snippet trigger.
This has the benefit of being able to expand snippets that are not neccessarily a word as selected by <kbd>b</kbd> and being able to select a trigger even when it is attached to another word.

For example, suppose my trigger is called "test" and I have the following buffer:
```
footest[]
```
Then test will be expanded as a snippet.