### PR TITLE
Implement auto-discard of snippets default text

### DIFF
--- a/snippets-directory.kak
+++ b/snippets-directory.kak
@@ -89,7 +89,6 @@ define-command snippets-directory-reload %{
     # TODO unset and re-set the 'filetype' of each open buffer so that it has the latest snippets
 }
 
-
 define-command -docstring "snippets-add-snippet <trigger> <description> [<filetype>]: Create new snippet for given filetype.
 If filetype is ommited, the current active filetype is used.
 If 'filetype' is not currently defined, the snippet is added in global scope.

--- a/snippets-directory.kak
+++ b/snippets-directory.kak
@@ -133,8 +133,6 @@ define-command -hidden snippets-add-snippet-impl -params 2..3 %{ evaluate-comman
             filename="$dir/$filetype/$trigger - $description"
             [ -z "${filename##*\'*}" ] && filename=$(printf %s "$filename" | sed "s/'/''''/g")
             printf " ' snippets-add-menu-action ''%s'' ' " "$filename"
-
-            shift
         done
     fi
 }}

--- a/snippets.kak
+++ b/snippets.kak
@@ -274,7 +274,7 @@ def snippets-insert -hidden -params 1 %<
 
 define-command -hidden snippets-insert-perl-impl %{
     evaluate-commands %sh{
-        # $kak_selections $kak_client
+        # $kak_selections
         perl ${kak_opt_snippets_source%/*}/snippets.pl
     }
     execute-keys R

--- a/snippets.kak
+++ b/snippets.kak
@@ -330,9 +330,10 @@ print("\n");
 >
 
 def -hidden snippets-setup-auto-discard %{
-    hook window -group auto-discard InsertChar .* %{ exec "<a-;>d%val{hook_param}"; remove-hooks window auto-discard }
-    hook window -group auto-discard InsertEnd .* %{ remove-hooks window auto-discard }
-    hook window -group auto-discard InsertMove .* %{ remove-hooks window auto-discard }
+    remove-hooks window snippets-auto-discard
+    hook window -group snippets-auto-discard InsertChar .* %{ remove-hooks window snippets-auto-discard; exec "<a-;>d%val{hook_param}" }
+    hook window -group snippets-auto-discard InsertEnd .* %{ remove-hooks window snippets-auto-discard }
+    hook window -group snippets-auto-discard InsertMove .* %{ remove-hooks window snippets-auto-discard }
 }
 
 def snippets-select-next-placeholders %{

--- a/snippets.kak
+++ b/snippets.kak
@@ -340,8 +340,8 @@ def snippets-select-next-placeholders %{
     eval %sh{
         eval set -- "$kak_opt_snippets_placeholder_info"
         if [ $# -eq 0 ]; then printf "fail 'There are no next placeholders'"; exit; fi
-        next_id=9999
-        second_next_id=9999
+        next_id=10000
+        second_next_id=10000
         next_has_default=''
         for placeholder_info do
             placeholder_id="${placeholder_info%|*}"

--- a/snippets.pl
+++ b/snippets.pl
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+use Text::ParseWords();
+
+my $client = $ENV{"kak_client"};
+my @sel_content = Text::ParseWords::shellwords($ENV{"kak_selections"});
+
+my %placeholder_id_to_default;
+my @placeholder_ids;
+
+for my $i (0 .. $#sel_content) {
+    my $sel = $sel_content[$i];
+    $sel =~ s/\A\$\{?|\}\Z//g;
+    my ($placeholder_id, $placeholder_default) = ($sel =~ /^(\d+)(?::(.*))?$/);
+    if ($placeholder_id eq "0") {
+        $placeholder_id = "9999";
+    }
+    $placeholder_ids[$i] = $placeholder_id;
+    if (defined($placeholder_default)) {
+        $placeholder_id_to_default{$placeholder_id} = $placeholder_default;
+    }
+}
+
+print("evaluate-commands -client $client %{ set-option window snippets_placeholder_info");
+for my $placeholder_id (@placeholder_ids) {
+    print(" $placeholder_id");
+    if (exists $placeholder_id_to_default{$placeholder_id}) {
+        print("|1");
+    } else {
+        print("|0");
+    }
+}
+print("}\n");
+
+print("evaluate-commands -client $client %{ set-register dquote");
+for my $placeholder_id (@placeholder_ids) {
+    if (exists $placeholder_id_to_default{$placeholder_id}) {
+        my $default = $placeholder_id_to_default{$placeholder_id};
+        # de-double up closing braces
+        $default =~ s/\}\}/}/g;
+        # double up single-quotes
+        $default =~ s/'/''/g;
+        print(" '$default'");
+    } else {
+        print(" ''");
+    }
+}
+print("}\n");

--- a/snippets.pl
+++ b/snippets.pl
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Text::ParseWords();
 
-my $client = $ENV{"kak_client"};
 my @sel_content = Text::ParseWords::shellwords($ENV{"kak_selections"});
 
 my %placeholder_id_to_default;
@@ -21,7 +20,7 @@ for my $i (0 .. $#sel_content) {
     }
 }
 
-print("evaluate-commands -client $client %{ set-option window snippets_placeholder_info");
+print("set-option window snippets_placeholder_info");
 for my $placeholder_id (@placeholder_ids) {
     print(" $placeholder_id");
     if (exists $placeholder_id_to_default{$placeholder_id}) {
@@ -30,9 +29,9 @@ for my $placeholder_id (@placeholder_ids) {
         print("|0");
     }
 }
-print("}\n");
+print("\n");
 
-print("evaluate-commands -client $client %{ set-register dquote");
+print("set-register dquote");
 for my $placeholder_id (@placeholder_ids) {
     if (exists $placeholder_id_to_default{$placeholder_id}) {
         my $default = $placeholder_id_to_default{$placeholder_id};
@@ -45,4 +44,4 @@ for my $placeholder_id (@placeholder_ids) {
         print(" ''");
     }
 }
-print("}\n");
+print("\n");


### PR DESCRIPTION
Should fix #8

For lack of a better idea, it's now implemented directly in the script. The auto-discard is removed as soon as insert mode is exited, or the selections were moved.