### PR TITLE
Speed up snippets-directory-reload

### DIFF
--- a/snippets-directory.kak
+++ b/snippets-directory.kak
@@ -48,8 +48,8 @@ sub print_kak_commands_for_filetype_dir {
 
         next if (! -f $snippet);
         $name =~ s/.*? - //;
-        next if ($name eq "");
-        if("$filetype/$name" eq $snippet) {
+        next if ($name eq "");               # no valid snippet name
+        if("$filetype/$name" eq $snippet) {  # no ' - ' in filename -> no trigger
             $trigger = "";
         } else {
             $trigger =~ s/ - .*//;
@@ -97,7 +97,7 @@ sub print_filetype_outro {
 
 sub multiply_single_quotes {
     my $text = shift;
-    my $levels = shift;
+    my $levels = shift;  # "levels" grows in powers of 2 as more escaping is needed
     my $substitute = "''";
     for(; $levels > 1; $levels--) { $substitute .= "''"; }
     $text =~ s/'/$substitute/g;

--- a/snippets-directory.kak
+++ b/snippets-directory.kak
@@ -79,13 +79,10 @@ sub print_snippet {
     print " ''", multiply_single_quotes($name, 2), "''";
     print " ''", multiply_single_quotes($trigger, 2), "''";
     print " ''snippets-insert ''''";
-    my $first_line = 1;
     open(my $fh, "<", $snippet) || die "Can't open < $snippet: $!";
     while (<$fh>) {
-        print "\n" if (! $first_line);
-        chomp;
+        chomp if eof;
         print multiply_single_quotes($_, 4);
-        $first_line = 0;
     }
     print "'''' ''";
     close($fh) || warn "close failed: $!";

--- a/snippets-directory.kak
+++ b/snippets-directory.kak
@@ -19,8 +19,6 @@ define-command snippets-directory-reload %{
                     gsub("'", substitute, text)
                     return text
                 }
-                BEGIN {
-                }
                 $1 ~ /^SNIPMARK_MISSING_DIR$/ {
                     sub("SNIPMARK_MISSING_DIR ", "")
                     printf "%s\n", "echo -debug 'Snippets directory ''" $0 "'' does not exist'"

--- a/snippets-directory.kak
+++ b/snippets-directory.kak
@@ -95,8 +95,7 @@ sub print_filetype_outro {
 sub multiply_single_quotes {
     my $text = shift;
     my $levels = shift;  # "levels" grows in powers of 2 as more escaping is needed
-    my $substitute = "''";
-    for(; $levels > 1; $levels--) { $substitute .= "''"; }
+    my $substitute = "''" x $levels;
     $text =~ s/'/$substitute/g;
     return $text;
 }


### PR DESCRIPTION
Since `printf` is no builtin in OpenBSD's sh (neither is `echo`), the `snippets-directory-reload` command was very slow. The calls of the `printf` command have been drastically reduced by buffering and utilizing `awk`.

I have tested the changes thoroughly by `tee`ing everything the `%sh{ ... }` block prints into a file and comparing between the original and new state. The outputs were completely identical.  

Since the `printf` command seems to be a builtin function in `dash` and the like, there is unfortunately no notable performance difference for the Linux users.

Here are some timings I recorded when using [the kakoune-snippet-collection](https://github.com/andreyorst/kakoune-snippet-collection) (I tried to select times, that were around the average for each scenario):
# Times with OpenBSD's `sh`
```shell
# Not using the plugin:
$ time kak -e 'q'
kak -e 'q'  0.03s user 0.12s system 94% cpu 0.159 total

# Old version:
$ time kak -e 'q'
kak -e 'q'  1.02s user 4.57s system 83% cpu 6.684 total

# awk version:
$ time kak -e 'q'
kak -e 'q'  0.26s user 0.19s system 108% cpu 0.416 total
```

# Times with `dash`
```shell
# Not using the plugin:
$ time kak -e 'q'
kak -e 'q'  0.08s user 0.16s system 134% cpu 0.178 total

# Old version:
$ time kak -e 'q'
kak -e 'q'  0.14s user 0.21s system 118% cpu 0.297 total

# awk version:
$ time kak -e 'q'
kak -e 'q'  0.10s user 0.20s system 98% cpu 0.305 total
```
