### PR TITLE
Provide kak modules

### DIFF
--- a/snippets-directory.kak
+++ b/snippets-directory.kak
@@ -1,4 +1,11 @@
-hook global KakBegin .* snippets-directory-reload
+hook global KakBegin .* %{
+    require-module snippets-directory
+    snippets-directory-reload
+}
+
+provide-module snippets-directory %{
+
+require-module snippets
 
 declare-option str-list snippets_directories "%val{config}/snippets"
 
@@ -158,4 +165,6 @@ define-command -hidden snippets-add-menu-action -params 1 %{
     }
     edit %arg{1}
     hook -group snippets-add-watchers buffer BufWritePost .* snippets-directory-reload
+}
+
 }

--- a/snippets.kak
+++ b/snippets.kak
@@ -1,3 +1,7 @@
+hook global KakBegin .* %{ require-module snippets }
+
+provide-module snippets %[
+
 # GENERIC SNIPPET PART
 
 decl -hidden regex snippets_triggers_regex "\A\z" # doing <a-k>\A\z<ret> will always fail
@@ -383,3 +387,5 @@ def snippets-select-next-placeholders %{
         printf "select %s\n" "$selections"
     }
 }
+
+]


### PR DESCRIPTION
For my setup the `kakoune-snippets` scripts were loaded only after my `kakrc` file was. Thus I couldn't set `snippets_directories` in my `kakrc` and I needed a way to change that. In [kakounes #2782](https://github.com/mawww/kakoune/pull/2782) modules were introduced.

I made changes so that `kakoune-snippets` now provides the modules `snippets` and `snippets-directory`. It might be a good idea to merge this pull request only after the next [kakoune release](https://github.com/mawww/kakoune/releases), since the module stuff isn't available in the current release.