### PR TITLE
Convert one more variable to $kak_quoted_...

### DIFF
--- a/snippets.kak
+++ b/snippets.kak
@@ -267,13 +267,13 @@ def snippets-insert -hidden -params 1 %<
 >
 
 def -hidden snippets-insert-perl-impl %<
-    eval %sh< # $kak_selections
+    eval %sh< # $kak_quoted_selections
         perl -e '
 use strict;
 use warnings;
 use Text::ParseWords();
 
-my @sel_content = Text::ParseWords::shellwords($ENV{"kak_selections"});
+my @sel_content = Text::ParseWords::shellwords($ENV{"kak_quoted_selections"});
 
 my %placeholder_id_to_default;
 my @placeholder_ids;


### PR DESCRIPTION
I had missed this occurrence of a list variable in my previous pull request. Sorry for the hassle, I hadn't tested enough. I think that's the last one.

Not using the quoted variable caused e.g. the `for` loop snippet for C from https://github.com/andreyorst/kakoune-snippet-collection to insert placeholders weirdly.